### PR TITLE
get_all_permissions() cannot be expected on all authentication backends

### DIFF
--- a/river/driver/orm_driver.py
+++ b/river/driver/orm_driver.py
@@ -48,7 +48,8 @@ class OrmDriver(RiverDriver):
 
         permissions = []
         for backend in auth.get_backends():
-            permissions.extend(backend.get_all_permissions(as_user))
+            if hasattr(backend, "get_all_permissions"):
+                permissions.extend(backend.get_all_permissions(as_user))
 
         permission_q = Q()
         for p in permissions:


### PR DESCRIPTION
For example, graphql_jwt authentication backend does not have get_all_permissions. If a developer uses authentication via GraphQL JWT, he ends up in an error, hence a check need to be added while accessing specific methods.